### PR TITLE
#110 커버 사진 없을 때 빈 배경색이 나오도록 처리

### DIFF
--- a/frontend/components/Banner/Banner.tsx
+++ b/frontend/components/Banner/Banner.tsx
@@ -92,7 +92,12 @@ const Banner = ({
             </div>
           </div>
         )}
-        <img src={backgroundImage} />
+        <img
+          src={
+            backgroundImage ||
+            'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+          }
+        />
       </div>
       <div
         className={cx('profile')}


### PR DESCRIPTION
- 커버 사진이 없으면 투명 1px svg 이미지 파일을 src에 설정해서 문제 해결